### PR TITLE
Fix issue with migration when it fails

### DIFF
--- a/sqlx.go
+++ b/sqlx.go
@@ -107,7 +107,7 @@ func (s *Sqlx) runMigration(db *sqlx.DB, m SqlxMigration) error {
 	if err != nil {
 		return errorf(err)
 	}
-	_, err = db.Exec("INSERT INTO migrations (id) VALUES ($1)", m.ID)
+	_, err = tx.Exec("INSERT INTO migrations (id) VALUES ($1)", m.ID)
 	if err != nil {
 		tx.Rollback()
 		return errorf(err)
@@ -131,7 +131,7 @@ func (s *Sqlx) runRollback(db *sqlx.DB, m SqlxMigration) error {
 	if err != nil {
 		return errorf(err)
 	}
-	_, err = db.Exec("DELETE FROM migrations WHERE id=$1", m.ID)
+	_, err = tx.Exec("DELETE FROM migrations WHERE id=$1", m.ID)
 	if err != nil {
 		tx.Rollback()
 		return errorf(err)


### PR DESCRIPTION
Instead of using the transaction to call Exec, the database is used which causes the rollback to not revert the new migration row.